### PR TITLE
Reflect new Label Upload API

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Endpoint Names:
 - ✔️ `statistics`
 - ✔️ `label_list`
 - ✔️ `label_detail`
+- ❌ `label_upload`
 - ✔️ `doc_list`
 - ✔️ `doc_detail`
 - ✔️ `doc_uploader`


### PR DESCRIPTION
New Label Upload API added in Doccano, see doccano/doccano#651.